### PR TITLE
Load all spell tabs for retail

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -509,7 +509,7 @@ do
         local sb = spells[btype]
 
         if IS_RETAIL_RELEASE then
-            local offsets, numTabs
+            local _, numTabs
             numTabs = GetNumSpellTabs()
             for i = 1, numTabs do
                 local _, _, offset, numSpells = GetSpellTabInfo(i)
@@ -559,7 +559,7 @@ do
 				end
 			end
         elseif IS_CLASSIC then
-            local offsets, numTabs
+            local _, numTabs
             numTabs = GetNumSpellTabs()
             for i = 1, numTabs do
                 local _, _, offset, numSpells = GetSpellTabInfo(i)

--- a/core.lua
+++ b/core.lua
@@ -509,51 +509,55 @@ do
         local sb = spells[btype]
 
         if IS_RETAIL_RELEASE then
-            local _, _, offset, numSpells = GetSpellTabInfo(2)
-            for i = 1, offset + numSpells do
-                local spellName = GetSpellBookItemName(i, btype)
-                if not spellName then break end
-                local spellType, spellID = GetSpellBookItemInfo(i, btype)
-                if spellID and spellType == "FLYOUT" then
-                    local _, _, numSlots, isKnown = GetFlyoutInfo(spellID)
-                    if isKnown then
-                        for j = 1, numSlots do
-                            local flyID, _, _, flyName = GetFlyoutSlotInfo(spellID, j)
-                            lastID                     = flyID
-                            if flyID then
-                                local flyCD = GetSpellBaseCooldown(flyID)
-                                if flyCD and flyCD > 2499 then
-                                    sb[flyID] = flyName -- specialspells[flyID] or flyName
-                                end
-                            end
-                        end
-                    end
-                elseif spellID and spellType == "SPELL" and spellID ~= lastID then
-                    -- Base spell = slot ID + name from slot ID
-                    -- Real spell = ID from slot name + name from slot name
-                    -- For the purposes of CoolLine we only care about the real spell.
-                    lastID                            = spellID
-                    spellName, _, _, _, _, _, spellID = GetSpellInfo(spellName)
-                    if spellID then
-                        -- Special spells like warlock Cauterize Master can be in
-                        -- a limbo state during loading. Just ignore them in that
-                        -- case. The spellbook will update again momentarily and
-                        -- they will correctly resolve then.
-                        local _, maxCharges = GetSpellCharges(spellID)
-                        if maxCharges and maxCharges > 0 then
-                            chargespells[btype][spellID] = spellName
-                        else
-                            local cd = GetSpellBaseCooldown(spellID)
-                            if cd and cd > 2499 then
-                                sb[spellID] = spellName
-                                --			if specialspells[spellName] then
-                                --				sb[ specialspells[spellName] ] = spellName
-                                --			end
-                            end
-                        end
-                    end
-                end
-            end
+            local offsets, numTabs
+            numTabs = GetNumSpellTabs()
+            for i = 1, numTabs do
+                local _, _, offset, numSpells = GetSpellTabInfo(i)
+				for i = 1, offset + numSpells do
+					local spellName = GetSpellBookItemName(i, btype)
+					if not spellName then break end
+					local spellType, spellID = GetSpellBookItemInfo(i, btype)
+					if spellID and spellType == "FLYOUT" then
+						local _, _, numSlots, isKnown = GetFlyoutInfo(spellID)
+						if isKnown then
+							for j = 1, numSlots do
+								local flyID, _, _, flyName = GetFlyoutSlotInfo(spellID, j)
+								lastID                     = flyID
+								if flyID then
+									local flyCD = GetSpellBaseCooldown(flyID)
+									if flyCD and flyCD > 2499 then
+										sb[flyID] = flyName -- specialspells[flyID] or flyName
+									end
+								end
+							end
+						end
+					elseif spellID and spellType == "SPELL" and spellID ~= lastID then
+						-- Base spell = slot ID + name from slot ID
+						-- Real spell = ID from slot name + name from slot name
+						-- For the purposes of CoolLine we only care about the real spell.
+						lastID                            = spellID
+						spellName, _, _, _, _, _, spellID = GetSpellInfo(spellName)
+						if spellID then
+							-- Special spells like warlock Cauterize Master can be in
+							-- a limbo state during loading. Just ignore them in that
+							-- case. The spellbook will update again momentarily and
+							-- they will correctly resolve then.
+							local _, maxCharges = GetSpellCharges(spellID)
+							if maxCharges and maxCharges > 0 then
+								chargespells[btype][spellID] = spellName
+							else
+								local cd = GetSpellBaseCooldown(spellID)
+								if cd and cd > 2499 then
+									sb[spellID] = spellName
+									--			if specialspells[spellName] then
+									--				sb[ specialspells[spellName] ] = spellName
+									--			end
+								end
+							end
+						end
+					end
+				end
+			end
         elseif IS_CLASSIC then
             local offsets, numTabs
             numTabs = GetNumSpellTabs()


### PR DESCRIPTION
9.0 splits the spellbook into base class and specialization spells, so we have to load all the spell tabs like the classic spell loading code does. The diff in this PR is nasty, but really all I did was nest the existing spell loading logic into a loop to load all the spell book tabs (and then indent the contained logic). The rest of the logic is unchanged. Without this change, not all spells will trigger a cooldown tracker.
```
            local _, _, offset, numSpells = GetSpellTabInfo(2)
```
to
```
            local _, numTabs
            numTabs = GetNumSpellTabs()
            for i = 1, numTabs do
                local _, _, offset, numSpells = GetSpellTabInfo(i)
```