### PR TITLE
Fix pet action textures

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -706,8 +706,7 @@ function CoolLine:PET_BAR_UPDATE_COOLDOWN()
     for i = 1, 10 do
         local start, duration, enable = GetPetActionCooldown(i)
         if enable == 1 then
-            local name, _, texture
-            name, texture = GetPetActionInfo(i)
+            local name, texture = GetPetActionInfo(i)
             if name then
                 if start > 0 and not block[name] then
                     if duration > 3 then

--- a/core.lua
+++ b/core.lua
@@ -707,11 +707,7 @@ function CoolLine:PET_BAR_UPDATE_COOLDOWN()
         local start, duration, enable = GetPetActionCooldown(i)
         if enable == 1 then
             local name, _, texture
-            if IS_RETAIL_RELEASE then
-                name, texture = GetPetActionInfo(i)
-            else
-                name, _, texture = GetPetActionInfo(i)
-            end
+            name, texture = GetPetActionInfo(i)
             if name then
                 if start > 0 and not block[name] then
                     if duration > 3 then


### PR DESCRIPTION
The Classic return values for `GetPetActionInfo(i)` have been changed to match the retail ones, so there's no longer a need for an empty value in Classic builds.